### PR TITLE
Fixed CORS origin issue when accessing API

### DIFF
--- a/backend-and-api/src/main/java/com/example/backendandapi/api/controller/APIController.java
+++ b/backend-and-api/src/main/java/com/example/backendandapi/api/controller/APIController.java
@@ -27,7 +27,6 @@ public class APIController {
     }
 
     @GetMapping("/api/image-links")
-    @CrossOrigin(origins = "http://localhost:3000")
     public ResponseEntity<APIResponseInterface[]> getResponse(@RequestParam String breed, @RequestParam int imageNumber) {
         String breedID;
         APIRequestBody body;

--- a/backend-and-api/src/main/java/com/example/backendandapi/config/CORSConfig.java
+++ b/backend-and-api/src/main/java/com/example/backendandapi/config/CORSConfig.java
@@ -1,0 +1,13 @@
+package com.example.backendandapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CORSConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*").allowedMethods("*");
+    }
+}


### PR DESCRIPTION
## Hotfix API CORS origin
Fixed the issue of getting a CORS Origin error when trying to make a request from the web interface if you access the website from other sources outside of `localhost:3000` (for example if you access the website from your local network using the IPv4 address of the machine that the app is hosted on)

## Insights of the code
Created a new `@Configuration`[^1] class stored in `configuration.CORSConfig.java` which overrides the `WebMvcConvigurer`[^2] parent method  `addCorsMappings()`[^3] and adds a CORS origin for all IP addresses. 
Removed the `@CrossOrigin` tag from the API controller since it's no longer needed.

[^1]: [@Configuration](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html)
[^2]: [WebMvcConfigurer](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.html)
[^3]: [addCorsMappings()](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/WebMvcConfigurer.html#addCorsMappings(org.springframework.web.servlet.config.annotation.CorsRegistry))